### PR TITLE
Support `--flavor` and `--test-session-name` options of `launchable record session` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'windows-latest']
+        version: ['v1', 'v2']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,6 +51,7 @@ jobs:
         with:
           report_path: .
           test_runner: <YOUR TEST RUNNER HERE>
+          flavors: 'os=${{ matrix.os }}, version=${{ matrix.version }}'
         if: always()
         env:
           LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
@@ -107,6 +111,14 @@ Flag to record test session without recording build. Default `false`, which mean
 ### `python_version`
 
 Python version for the Launchable CLI to use. Default is `3.10`. Change this if your workflow requires a specific Python version.
+
+### `test_session_name`
+
+Test session name that you can give to the value to [`--test-session-name`](https://www.launchableinc.com/docs/resources/cli-reference/#3500669-record-session) option of the `record session` command. (Optional)
+
+### `flavors`
+
+The value that you can give to the value to ['--flavor](https://www.launchableinc.com/docs/resources/cli-reference/#3500669-record-session) option to the `record session` command. e.g.) `os=linux, version=v1` (Optional)
 
 # License
 Launchable data collection action is licensed under [Apache license](./LICENSE).

--- a/action.yaml
+++ b/action.yaml
@@ -71,16 +71,18 @@ runs:
     - id: record_test
       shell: bash
       run: |
+        options=(
+          "--allow-test-before-build"
+        )
+
         if [ "${{ inputs.no_build }}" == "true" ]; then
-          launchable record tests \
-            --allow-test-before-build \
-            --no-build \
-            ${{ inputs.test_runner }} \
-            ${{ inputs.report_path }}
-        else
-          launchable record tests \
-            --build ${{ inputs.build_name }} \
-            --allow-test-before-build \
-            ${{ inputs.test_runner }} \
-            ${{ inputs.report_path }}
+          rm -f .launchable
+          options+=("--no-build")
         fi
+
+        options+=(
+            ${{ inputs.test_runner }} \
+            ${{ inputs.report_path }}
+        )
+
+        launchable record tests "${options[@]}"

--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,10 @@ inputs:
   test_runner:
     required: true
     description: "test runner name"
+  test_session_name:
+    required: false
+    description: "The test session name for `--session-name` option of record session command"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -67,7 +71,18 @@ runs:
         if [ "${{ inputs.no_submodules }}" == "true" ]; then
           options+=("--no-submodules")
         fi
+
         launchable record build "${options[@]}"
+    - id: record_session
+      shell: bash
+      run: |
+        options=(
+          "--build" "${{ inputs.build_name }}"
+        )
+        if [ "${{ inputs.test_session_name }}" ]; then
+          options+=("--session-name" "${{ inputs.test_session_name }}")
+        fi
+        launchable record session "${options[@]}"
     - id: record_test
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -58,18 +58,16 @@ runs:
       shell: bash
       if: inputs.no_build != 'true'
       run: |
-        if [ "${{ inputs.no_submodules }}" == "false" ]; then
-          launchable record build \
-            --name ${{ inputs.build_name }} \
-            --max-days ${{ inputs.max_days }} \
-            --source src=${{ inputs.source_path }}
-        else
-          launchable record build \
-            --name ${{ inputs.build_name }} \
-            --max-days ${{ inputs.max_days }} \
-            --source src=${{ inputs.source_path }} \
-            --no-submodules
+        options=(
+          "--name" "${{ inputs.build_name }}"
+          "--max-days" "${{ inputs.max_days }}"
+          "--source" "src=${{ inputs.source_path }}"
+        )
+
+        if [ "${{ inputs.no_submodules }}" == "true" ]; then
+          options+=("--no-submodules")
         fi
+        launchable record build "${options[@]}"
     - id: record_test
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -74,6 +74,7 @@ runs:
 
         launchable record build "${options[@]}"
     - id: record_session
+      if: inputs.no_build != 'true'
       shell: bash
       run: |
         options=(
@@ -91,7 +92,6 @@ runs:
         )
 
         if [ "${{ inputs.no_build }}" == "true" ]; then
-          rm -f .launchable
           options+=("--no-build")
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -92,6 +92,10 @@ runs:
         )
 
         if [ "${{ inputs.no_build }}" == "true" ]; then
+          # If this action is called multiple times in a workflow, there is a possibility that .launchable file is already created.
+          # So, try to remove it to avoid the conflict, just in case.
+          rm -f .launchable
+
           options+=("--no-build")
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ inputs:
     description: "test runner name"
   test_session_name:
     required: false
-    description: "The test session name for `--session-name` option of record session command"
+    description: "The test session name for `--session-name` option of record session command. test-session name value This value needs to be globally unique"
     default: ""
   flavors:
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,10 @@ inputs:
     required: false
     description: "The test session name for `--session-name` option of record session command"
     default: ""
+  flavors:
+    required: false
+    description: "The flavors for `--flavor` option of record session command"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -80,6 +84,16 @@ runs:
         options=(
           "--build" "${{ inputs.build_name }}"
         )
+
+        # Set up flavors options
+        if [ -n "${{ inputs.flavors }}" ]; then
+          IFS=', ' read -r -a flavors <<< "${{ inputs.flavors }}"
+          for flavor in "${flavors[@]}"; do
+            options+=("--flavor" "$flavor")
+          done
+        fi
+
+        # Set up test session name option
         if [ "${{ inputs.test_session_name }}" ]; then
           options+=("--session-name" "${{ inputs.test_session_name }}")
         fi
@@ -91,7 +105,7 @@ runs:
         exit_code=$?
 
         if [[ $output == *"is already used"* ]]; then
-          echo "INFO: test_session_name: '${{ inputs.test_session_name }}' of build: '${{ inputs.build_name }}' is already registered"
+          echo "INFO: test_session_name: '${{ inputs.test_session_name }}' is already registered. New test session wasn't created."
           exit_code=0
         else
           echo $output
@@ -111,6 +125,14 @@ runs:
           rm -f .launchable
 
           options+=("--no-build")
+
+          # Set up flavors options
+          if [ -n "${{ inputs.flavors }}" ]; then
+            IFS=', ' read -r -a flavors <<< "${{ inputs.flavors }}"
+            for flavor in "${flavors[@]}"; do
+              options+=("--flavor" "$flavor")
+            done
+          fi
         fi
 
         if [ "${{ inputs.test_session_name }}" ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -83,7 +83,21 @@ runs:
         if [ "${{ inputs.test_session_name }}" ]; then
           options+=("--session-name" "${{ inputs.test_session_name }}")
         fi
-        launchable record session "${options[@]}"
+
+        # In some case (e.g. parallel execution), wants to use the same ses sion name.
+        # So, allow the case that the session name is already used.
+        set +e
+        output=$(launchable record session "${options[@]}" 2>&1)
+        exit_code=$?
+
+        if [[ $output == *"is already used"* ]]; then
+          echo "INFO: test_session_name: '${{ inputs.test_session_name }}' of build: '${{ inputs.build_name }}' is already registered"
+          exit_code=0
+        else
+          echo $output
+        fi
+
+        exit $exit_code
     - id: record_test
       shell: bash
       run: |
@@ -97,6 +111,13 @@ runs:
           rm -f .launchable
 
           options+=("--no-build")
+        fi
+
+        if [ "${{ inputs.test_session_name }}" ]; then
+          options+=(
+            "--build" "${{ inputs.build_name }}"
+            "--session-name" "${{ inputs.test_session_name }}"
+          )
         fi
 
         options+=(


### PR DESCRIPTION
This [action](https://github.com/marketplace/actions/record-build-and-test-results-action) didn't support `--flavor` and `--test-session-name` option.

So updated to support it. See also https://github.com/launchableinc/examples/pull/81