### PR TITLE
update actions versions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,13 +48,14 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: ${{ inputs.python_version }}
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: 8
     - id: install
       shell: bash
       run: pip install "launchable>=1.59.0"

--- a/action.yaml
+++ b/action.yaml
@@ -144,8 +144,8 @@ runs:
         fi
 
         options+=(
-            ${{ inputs.test_runner }} \
-            ${{ inputs.report_path }}
+            "${{ inputs.test_runner }}"
+            "${{ inputs.report_path }}"
         )
 
         launchable record tests "${options[@]}"


### PR DESCRIPTION
We used old version GitHub actions and its use node16. However node16 is already deprecated (see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

So, I updated these actions versions